### PR TITLE
Remove `~` in nom dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 piston_meta = "0.15.0"
-nom = "~1.0.0"
+nom = "1.0.0"
 vec_map = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Eco doesn’t handle `~` dependencies yet.
